### PR TITLE
[Trivial] Logic optimisation + Typo/style corrections

### DIFF
--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -375,17 +375,17 @@ endregion comment_extraction
 /*
 region helper functions
 */
-fn extract_continuation_token(continuation_item_render: &Value) -> String{
+fn extract_continuation_token(continuation_item_render: &Value) -> String {
     return unwrap_to_string(continuation_item_render["continuationEndpoint"]["continuationCommand"]["token"].as_str());
 }
-fn extract_browse_endpoint(navigation_endpoint: &Value) -> EndpointBrowse{
+fn extract_browse_endpoint(navigation_endpoint: &Value) -> EndpointBrowse {
     EndpointBrowse { 
         url: unwrap_to_string(navigation_endpoint["commandMetadata"]["webCommandMetadata"]["url"].as_str()), 
         browse_id:unwrap_to_string(navigation_endpoint["browseEndpoint"]["browseId"].as_str()), 
         params: String::from(""),
     }
 }
-fn extract_watch_endpoint(navigation_endpoint: &Value) -> EndpointWatch{
+fn extract_watch_endpoint(navigation_endpoint: &Value) -> EndpointWatch {
     EndpointWatch { 
         url: unwrap_to_string(navigation_endpoint["commandMetadata"]["webCommandMetadata"]["url"].as_str()), 
         video_id: unwrap_to_string(navigation_endpoint["watchEndpoint"]["videoId"].as_str()),
@@ -396,14 +396,9 @@ fn extract_watch_endpoint(navigation_endpoint: &Value) -> EndpointWatch{
 // Runs means there is a text field and an navigationEndpoint field 
 // Badges can be optionally supplied, they are used to determine is the author is verified
 fn extract_author(runs: &Value, badges: Option<&Value>) -> Author {
-    let mut verified: bool = false;
-    if badges.is_some() {
-        verified = is_author_verified(&badges.unwrap()[0]);
-    }
-    
     Author {
         name: unwrap_to_string(runs[0]["text"].as_str()),
-        verified,
+        verified: badges.is_some() && is_author_verified(&badges.unwrap()[0]),
         browse_endpoint: extract_browse_endpoint(&runs[0]["navigationEndpoint"]),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,7 @@ async fn test_resolve_url_extractor_success(){
 }
 
 #[tokio::test]
-async fn test_search_extractor_sucess(){
+async fn test_search_extractor_success(){
   let client_config = &default_client_config();
   let result = extractors::extract_search_result(&endpoints::search("ltt","",client_config).await.unwrap());
   assert_eq!(result.is_ok(), true);
@@ -905,7 +905,7 @@ async fn test_search_extractor_error(){
 }
 
 #[tokio::test]
-async fn test_next_extractor_sucess(){
+async fn test_next_extractor_success(){
   let client_config = &default_client_config();
   let result = extractors::extract_next_result(&endpoints::next_with_data(json!({
     "videoId": "td6zO4r2ogI"
@@ -922,7 +922,7 @@ async fn test_next_extractor_error(){
 }
 
 #[tokio::test]
-async fn test_browse_extractor_sucess(){
+async fn test_browse_extractor_success(){
   let client_config = &default_client_config();
   let result = extractors::extract_browse_result(&endpoints::browse_browseid("UCXuqSBlHAE6Xw-yeJA0Tunw","EgZ2aWRlb3O4AQA%3D",client_config).await.unwrap());
   assert_eq!(result.is_ok(), true);


### PR DESCRIPTION
- Shortens the `extract_author` logic, also removing a mutable in favour of an inline conditional.
- Fixes a few styling issues (lack of whitespace).
- Typo corrections.

*Compiled and tested!* - `cargo check && cargo test` :heavy_check_mark: 