### PR TITLE
Fixed unknown type recognitionShelfRenderer fixes #4

### DIFF
--- a/src/types/misc.rs
+++ b/src/types/misc.rs
@@ -400,7 +400,8 @@ pub enum  ItemSectionRendererContents{
     SearchPyvRenderer(Value), // TODO FIND OUT WHAT IT IS
     CommentsEntryPointHeaderRenderer(Value),
     RadioRenderer(RadioRenderer), // Wrapper for CompactRadioRenderer
-    ChannelAboutFullMetadataRenderer(ChannelAboutFullMetadataRenderer)
+    ChannelAboutFullMetadataRenderer(ChannelAboutFullMetadataRenderer),
+    RecognitionShelfRenderer(Value), // Channel members but needs more investigation
 }
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Adds RecognitionShelfRenderer to the ItemSectionRendererContents enum but its not getting parsed since its not needed but should probably be parsed in a future release