### PR TITLE
Added json dump on error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "youtubei-rs"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "youtubei-rs"
-version = "1.4.6"
+version = "1.4.7"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "youtubei-rs"
-version = "1.4.7"
+version = "1.4.6"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "youtubei-rs"
-version = "1.3.5"
+version = "1.4.5"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtubei-rs"
-version = "1.4.7"
+version = "1.4.6"
 edition = "2021"
 license = "AGPL-3.0-only"
 keywords = ["api", "youtube","innertube", "wrapper"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtubei-rs"
-version = "1.4.5"
+version = "1.4.6"
 edition = "2021"
 license = "AGPL-3.0-only"
 keywords = ["api", "youtube","innertube", "wrapper"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtubei-rs"
-version = "1.3.5"
+version = "1.4.5"
 edition = "2021"
 license = "AGPL-3.0-only"
 keywords = ["api", "youtube","innertube", "wrapper"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youtubei-rs"
-version = "1.4.6"
+version = "1.4.7"
 edition = "2021"
 license = "AGPL-3.0-only"
 keywords = ["api", "youtube","innertube", "wrapper"]

--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 A asynchronous implementation of the invidious innertube aka youtubei API wrapper. <br>
 Using tokio,reqwest, serde and serde_json.
 
-# Breaking changes in version bump 0.2.3 to 1.2.3
-- old queries are now prefixed with _legacy, if you rely on those just rename them in your program they still function the same
-# Dependencies
-- serde_json 
-- serde: features = ["derive"]
-- reqwest: features = ["json","gzip"]
-- tokio: features = ["full"]
+# Configuration
+The client_config can be configured to dump the json response to a file if its not parsable,</br>
+this is on by default when using the `default_client_config()` function.</br>
+When creating the client_config manually you can parse true/false as the last parameter to disable this behavior.
 
 # Roadmap
 - implementing proxy support
@@ -30,7 +27,7 @@ Using tokio,reqwest, serde and serde_json.
 - resolve, // Resolve a given url
 - player // Get player data for a given videoId
 
-# Example 
+# Example
 ```rust
 use youtubei_rs::{query::player, utils::default_client_config, types::query_results::PlayerResult};
 #[tokio::main]

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,25 +1,30 @@
-use serde_json::Value;
+use std::fs;
+
 use serde_json::json;
+use serde_json::Value;
 use tracing::Level;
 
 use crate::endpoints;
 use crate::endpoints::*;
 use crate::extractors::*;
-use crate::types::channel::{ChannelTab,Tab};
+use crate::types::channel::{ChannelTab, Tab};
 use crate::types::client::ClientConfig;
 use crate::types::error::Errors;
+use crate::types::error::RequestError;
 use crate::types::playlist::Playlist;
 use crate::types::query_results::BrowseResult;
 use crate::types::query_results::NextResult;
 use crate::types::query_results::PlayerResult;
 use crate::types::query_results::ResolveResult;
 use crate::types::query_results::SearchResult;
-use crate::types::query_results::{CommentsQuery, VideoQuery, ChannelQuery,SearchQuery};
-use crate::types::video::{SearchVideo,Video};
-use crate::types::error::RequestError;
+use crate::types::query_results::{ChannelQuery, CommentsQuery, SearchQuery, VideoQuery};
+use crate::types::video::{SearchVideo, Video};
 use crate::utils::unwrap_to_string;
 
-pub async fn search_legacy(query: String,client_config: &ClientConfig) -> Result<SearchQuery, RequestError>{
+pub async fn search_legacy(
+    query: String,
+    client_config: &ClientConfig,
+) -> Result<SearchQuery, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Searching with query {}",query);
     let json = endpoints::search(&query, "", &client_config).await;
     match json {
@@ -27,7 +32,10 @@ pub async fn search_legacy(query: String,client_config: &ClientConfig) -> Result
         Err(err) => Err(err),
     }
 }
-pub async fn load_search_legacy(continuation:String,client_config: &ClientConfig) ->Result<SearchQuery, RequestError>{
+pub async fn load_search_legacy(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<SearchQuery, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Continuing search with continuation {}",continuation);
     let json = endpoints::search_continuation(&continuation, &client_config).await;
     match json {
@@ -35,7 +43,10 @@ pub async fn load_search_legacy(continuation:String,client_config: &ClientConfig
         Err(err) => Err(err),
     }
 }
-pub async fn load_related_videos_legacy(continuation:String,client_config: &ClientConfig) -> Result<Vec<SearchVideo>, RequestError>{
+pub async fn load_related_videos_legacy(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<Vec<SearchVideo>, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading related videos with continuation {}",continuation);
     let json = next(&continuation, &client_config).await;
     match json {
@@ -43,7 +54,10 @@ pub async fn load_related_videos_legacy(continuation:String,client_config: &Clie
         Err(err) => Err(err),
     }
 }
-pub async fn get_comments_legacy(continuation:String,client_config: &ClientConfig) ->Result<CommentsQuery,  RequestError>{
+pub async fn get_comments_legacy(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<CommentsQuery, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading comments with continuation {}",continuation);
     let comments_json = next(&continuation, client_config).await;
     match comments_json {
@@ -51,7 +65,11 @@ pub async fn get_comments_legacy(continuation:String,client_config: &ClientConfi
         Err(err) => Err(err),
     }
 }
-pub async fn get_video_legacy(video_id:String, params: String,client_config: &ClientConfig) ->Result<VideoQuery,  RequestError>{
+pub async fn get_video_legacy(
+    video_id: String,
+    params: String,
+    client_config: &ClientConfig,
+) -> Result<VideoQuery, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading video with id {}",video_id);
     let player_json = endpoints::player(&video_id, &params, &client_config).await;
     /*
@@ -61,180 +79,345 @@ pub async fn get_video_legacy(video_id:String, params: String,client_config: &Cl
         Ok(result) => result,
         Err(err) => return Err(err),
     };
-    let res_next = next_with_data(serde_json::json!({
-        "videoId": video_id,
-        "params": params 
-    }),&client_config).await;
+    let res_next = next_with_data(
+        serde_json::json!({
+            "videoId": video_id,
+            "params": params
+        }),
+        &client_config,
+    )
+    .await;
     let next_video_data = match res_next {
         Ok(result) => result,
-        Err(err) => return Err(err)
+        Err(err) => return Err(err),
     };
     let video_player = extract_video_player_formats(&res["streamingData"]);
-    let video: Video = video_from_next_and_player(&res, &next_video_data["contents"]["twoColumnWatchNextResults"]["results"]["results"]["contents"], video_player);
-    Ok(extract_next_video_results(&next_video_data, VideoQuery{
-        continuation_comments: "".to_string(),
-        continuation_related: unwrap_to_string(next_video_data["contents"]["twoColumnWatchNextResults"]["secondaryResults"]["secondaryResults"]["results"][20]["continuationItemRenderer"]["continuationEndpoint"]["continuationCommand"]["token"].as_str()),
-        video,
-        related_videos: Vec::new(),
-    }))
+    let video: Video = video_from_next_and_player(
+        &res,
+        &next_video_data["contents"]["twoColumnWatchNextResults"]["results"]["results"]["contents"],
+        video_player,
+    );
+    Ok(extract_next_video_results(
+        &next_video_data,
+        VideoQuery {
+            continuation_comments: "".to_string(),
+            continuation_related: unwrap_to_string(
+                next_video_data["contents"]["twoColumnWatchNextResults"]["secondaryResults"]
+                    ["secondaryResults"]["results"][20]["continuationItemRenderer"]
+                    ["continuationEndpoint"]["continuationCommand"]["token"]
+                    .as_str(),
+            ),
+            video,
+            related_videos: Vec::new(),
+        },
+    ))
 }
-pub async fn get_channel_info_legacy(channel_id:String,client_config: &ClientConfig) -> Result<ChannelQuery,  RequestError>{
+pub async fn get_channel_info_legacy(
+    channel_id: String,
+    client_config: &ClientConfig,
+) -> Result<ChannelQuery, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading channel info for channel: {}", channel_id);
-    let complete_url = "https://www.youtube.com/channel/".to_owned() + &channel_id +"/about"; 
-    let resolved_url = resolve_url(&complete_url,&client_config ).await;
+    let complete_url = "https://www.youtube.com/channel/".to_owned() + &channel_id + "/about";
+    let resolved_url = resolve_url(&complete_url, &client_config).await;
     let res = match resolved_url {
         Ok(result) => result,
         Err(err) => return Err(err),
     };
     let channel_json = browse_browseid(
-        res["endpoint"]["browseEndpoint"]["browseId"].as_str().unwrap(), 
-        res["endpoint"]["browseEndpoint"]["params"].as_str().unwrap(), 
-        &client_config
-    ).await;
+        res["endpoint"]["browseEndpoint"]["browseId"]
+            .as_str()
+            .unwrap(),
+        res["endpoint"]["browseEndpoint"]["params"]
+            .as_str()
+            .unwrap(),
+        &client_config,
+    )
+    .await;
     match channel_json {
-        Ok(result) => Ok(ChannelQuery{
-            channel:extract_channel_info(&result),
+        Ok(result) => Ok(ChannelQuery {
+            channel: extract_channel_info(&result),
         }),
         Err(err) => return Err(err),
     }
 }
-pub async fn get_channel_tab_url_legacy(channel_id:String,tab: Tab, client_config: &ClientConfig) -> Result<ChannelTab, RequestError>{
+pub async fn get_channel_tab_url_legacy(
+    channel_id: String,
+    tab: Tab,
+    client_config: &ClientConfig,
+) -> Result<ChannelTab, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading channel tab: {} for channel: {}", tab.get_name(),channel_id);
     let index = tab.get_index();
-    let complete_url = "https://www.youtube.com/".to_owned() + &channel_id +"/about"; 
-    let resolved_url = resolve_url(&complete_url,&client_config).await;
+    let complete_url = "https://www.youtube.com/".to_owned() + &channel_id + "/about";
+    let resolved_url = resolve_url(&complete_url, &client_config).await;
     let res = match resolved_url {
         Ok(result) => result,
         Err(err) => return Err(err),
     };
     let channel_json = browse_browseid(
-        res["endpoint"]["browseEndpoint"]["browseId"].as_str().unwrap(), 
-        res["endpoint"]["browseEndpoint"]["params"].as_str().unwrap(), 
-        &client_config
-    ).await;
+        res["endpoint"]["browseEndpoint"]["browseId"]
+            .as_str()
+            .unwrap(),
+        res["endpoint"]["browseEndpoint"]["params"]
+            .as_str()
+            .unwrap(),
+        &client_config,
+    )
+    .await;
     match channel_json {
-        Ok(result) => Ok(extract_channel_tab(&result,index)),
+        Ok(result) => Ok(extract_channel_tab(&result, index)),
         Err(err) => Err(err),
     }
 }
-pub async fn get_channel_tab_continuation_legacy(continuation:String,tab: Tab, client_config: &ClientConfig) -> Result<ChannelTab, RequestError>{
+pub async fn get_channel_tab_continuation_legacy(
+    continuation: String,
+    tab: Tab,
+    client_config: &ClientConfig,
+) -> Result<ChannelTab, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading channel tab: {}, with continuation: {}", tab.get_name(),continuation);
     let index = tab.get_index();
-    let channel_json = endpoints::browse_continuation(&continuation,&client_config).await;
+    let channel_json = endpoints::browse_continuation(&continuation, &client_config).await;
     match channel_json {
-        Ok(result) => Ok(extract_channel_tab(&result,index)),
+        Ok(result) => Ok(extract_channel_tab(&result, index)),
         Err(err) => Err(err),
     }
 }
-pub async fn get_playlist_legacy(playlist_id: String,client_config: &ClientConfig)-> Result<Playlist, RequestError>{
+pub async fn get_playlist_legacy(
+    playlist_id: String,
+    client_config: &ClientConfig,
+) -> Result<Playlist, RequestError> {
     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Loading playlist with id: {}",playlist_id);
-    let complete_url = "https://www.youtube.com/playlist?list=".to_owned()+ &playlist_id;
-    let resolved_url = resolve_url(&complete_url,&client_config).await;
+    let complete_url = "https://www.youtube.com/playlist?list=".to_owned() + &playlist_id;
+    let resolved_url = resolve_url(&complete_url, &client_config).await;
     let res = match resolved_url {
         Ok(result) => result,
         Err(err) => return Err(err),
     };
     let playlist_json = browse_browseid(
-        res["endpoint"]["browseEndpoint"]["browseId"].as_str().unwrap(), 
-        "", 
-        &client_config
-    ).await;
+        res["endpoint"]["browseEndpoint"]["browseId"]
+            .as_str()
+            .unwrap(),
+        "",
+        &client_config,
+    )
+    .await;
     match playlist_json {
-        Ok(result) =>     Ok(extract_playlist(&result)),
+        Ok(result) => Ok(extract_playlist(&result)),
         Err(err) => return Err(err),
     }
 }
 
-pub async fn next_video_id(video_id:String, params: String,client_config: &ClientConfig) -> Result<NextResult, Errors>{
-    let json = next_with_data(json!({
-        "videoId": video_id,
-        "params": params,
-    }), client_config).await;
+pub async fn next_video_id(
+    video_id: String,
+    params: String,
+    client_config: &ClientConfig,
+) -> Result<NextResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing next request for video id: {} and params: {}",video_id,params);
+    let json = next_with_data(
+        json!({
+            "videoId": video_id,
+            "params": params,
+        }),
+        client_config,
+    )
+    .await;
     match json {
-        Ok(json) => match extract_next_result(&json){
+        Ok(json) => match extract_next_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, ID: {}, params: {}",err,video_id,params);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n ----------------------------------------------------", video_id,params));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_next"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn next_continuation(continuation:String,client_config: &ClientConfig) -> Result<NextResult, Errors>{
+pub async fn next_continuation(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<NextResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing next request for continuation: {}",continuation);
     let json = next(&continuation, client_config).await;
     match json {
-        Ok(json) => match extract_next_result(&json){
+        Ok(json) => match extract_next_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::DEBUG,"Dumping json for request with error: {}, CToken: {}",err,continuation);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_next_ctoken"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
 
-pub async fn browse_id(browse_id:String,params:String,client_config: &ClientConfig) -> Result<BrowseResult, Errors>{
-    let json = browse_browseid(&browse_id,&params ,client_config).await;
+pub async fn browse_id(
+    browse_id: String,
+    params: String,
+    client_config: &ClientConfig,
+) -> Result<BrowseResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing browse request for browse id: {} and params: {}",browse_id, params);
+    let json = browse_browseid(&browse_id, &params, client_config).await;
     match json {
-        Ok(json) => match extract_browse_result(&json){
+        Ok(json) => match extract_browse_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::DEBUG,"Dumping json for request with error: {}, ID: {}, params: {}",err,browse_id,params);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Browse ID: {} \n params: {} \n ----------------------------------------------------", browse_id,params));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_browse"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn browse_custom_data(data: Value, client_config: &ClientConfig) -> Result<BrowseResult, Errors>{
-    let json = browse_with_data(data,client_config).await;
+pub async fn browse_custom_data(
+    data: Value,
+    client_config: &ClientConfig,
+) -> Result<BrowseResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing browse request for browse data: {}",data);
+    let json = browse_with_data(data.clone(), client_config).await;
     match json {
-        Ok(json) => match extract_browse_result(&json){
+        Ok(json) => match extract_browse_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}",err);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Custom Data:\n {} \n ----------------------------------------------------", data.to_string()));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_browse_custom_data"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn browse_continuation(continuation:String,client_config: &ClientConfig) -> Result<BrowseResult, Errors>{
+pub async fn browse_continuation(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<BrowseResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing browse request for continuation: {}",continuation);
     let json = endpoints::browse_continuation(&continuation, client_config).await;
     match json {
-        Ok(json) => match extract_browse_result(&json){
+        Ok(json) => match extract_browse_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, CToken: {}",err, continuation);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_browse_ctoken"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn player(video_id:String,params:String,client_config: &ClientConfig) -> Result<PlayerResult, Errors>{
-    let json = endpoints::player(&video_id,&params ,client_config).await;
+pub async fn player(
+    video_id: String,
+    params: String,
+    client_config: &ClientConfig,
+) -> Result<PlayerResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing player request for video id: {} and params: {}",video_id, params);
+    let json = endpoints::player(&video_id, &params, client_config).await;
     match json {
-        Ok(json) => match extract_player_result(&json){
+        Ok(json) => match extract_player_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing player result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, ID: {}, params: {}",err,video_id,params);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n ----------------------------------------------------", video_id,params));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_player"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn resolve(url:String,client_config: &ClientConfig) -> Result<ResolveResult, Errors>{
-    let json = endpoints::resolve_url(&url ,client_config).await;
+pub async fn resolve(url: String, client_config: &ClientConfig) -> Result<ResolveResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing resolve request for url: {}",url);
+    let json = endpoints::resolve_url(&url, client_config).await;
     match json {
-        Ok(json) => match extract_resolve_result(&json){
+        Ok(json) => match extract_resolve_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing resolve result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, url: {}",err,url);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n URL: {} \n ----------------------------------------------------", url));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_resolve"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn search(query:String, params: String,client_config: &ClientConfig) -> Result<SearchResult, Errors>{
-    let json = endpoints::search(&query,&params,client_config).await;
+pub async fn search(
+    query: String,
+    params: String,
+    client_config: &ClientConfig,
+) -> Result<SearchResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing search request for query id: {} and params: {}",query, params);
+    let json = endpoints::search(&query, &params, client_config).await;
     match json {
-        Ok(json) => match extract_search_result(&json){
+        Ok(json) => match extract_search_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, Search query: {}, params: {}",err,query,params);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Search query: {} \n params: {} \n ----------------------------------------------------", query,params));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_search"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }
 }
-pub async fn search_continuation(continuation:String,client_config: &ClientConfig) -> Result<SearchResult, Errors>{
-    let json = endpoints::search_continuation(&continuation,client_config).await;
+pub async fn search_continuation(
+    continuation: String,
+    client_config: &ClientConfig,
+) -> Result<SearchResult, Errors> {
+    tracing::event!(target: "youtubei_rs",Level::TRACE,"Preparing search request for continuation: {}",continuation);
+    let json = endpoints::search_continuation(&continuation, client_config).await;
     match json {
-        Ok(json) => match extract_search_result(&json){
+        Ok(json) => match extract_search_result(&json) {
             Ok(result) => return Ok(result),
-            Err(err) => return Err(Errors::ParseError(err))
+            Err(err) => {
+                tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
+                if client_config.dump_on_error {
+                    tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, CToken: {}",err, continuation);
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    log += &json.to_string();
+                    fs::write(format!("json_dump_endpoint_search_ctoken"), log).unwrap();
+                }
+                return Err(Errors::ParseError(err));
+            }
         },
         Err(err) => return Err(Errors::RequestError(err)),
     }

--- a/src/query.rs
+++ b/src/query.rs
@@ -227,7 +227,7 @@ pub async fn next_video_id(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, ID: {}, params: {}",err,video_id,params);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n ----------------------------------------------------", video_id,params));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n Error {} \n----------------------------------------------------", video_id,params, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_next"), log).unwrap();
                 }
@@ -250,7 +250,7 @@ pub async fn next_continuation(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Dumping json for request with error: {}, CToken: {}",err,continuation);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n Error {} \n----------------------------------------------------", continuation, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_next_ctoken"), log).unwrap();
                 }
@@ -275,7 +275,7 @@ pub async fn browse_id(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::DEBUG,"Dumping json for request with error: {}, ID: {}, params: {}",err,browse_id,params);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n Browse ID: {} \n params: {} \n ----------------------------------------------------", browse_id,params));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Browse ID: {} \n params: {} \n Error {} \n ----------------------------------------------------", browse_id,params, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_browse"), log).unwrap();
                 }
@@ -298,7 +298,7 @@ pub async fn browse_custom_data(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}",err);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n Custom Data:\n {} \n ----------------------------------------------------", data.to_string()));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Custom Data:\n {} \n Error {} \n ----------------------------------------------------", data.to_string(), err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_browse_custom_data"), log).unwrap();
                 }
@@ -321,7 +321,7 @@ pub async fn browse_continuation(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing browse result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, CToken: {}",err, continuation);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n Error {} \n  ----------------------------------------------------", continuation, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_browse_ctoken"), log).unwrap();
                 }
@@ -345,7 +345,7 @@ pub async fn player(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing player result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, ID: {}, params: {}",err,video_id,params);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n ----------------------------------------------------", video_id,params));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Video ID: {} \n params: {} \n Error {} \n----------------------------------------------------", video_id,params, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_player"), log).unwrap();
                 }
@@ -365,7 +365,7 @@ pub async fn resolve(url: String, client_config: &ClientConfig) -> Result<Resolv
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing resolve result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, url: {}",err,url);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n URL: {} \n ----------------------------------------------------", url));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n URL: {} \n Error {} \n----------------------------------------------------", url, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_resolve"), log).unwrap();
                 }
@@ -389,7 +389,7 @@ pub async fn search(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, Search query: {}, params: {}",err,query,params);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n Search query: {} \n params: {} \n ----------------------------------------------------", query,params));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n Search query: {} \n params: {} \n Error {} \n ----------------------------------------------------", query,params, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_search"), log).unwrap();
                 }
@@ -412,7 +412,7 @@ pub async fn search_continuation(
                 tracing::event!(target: "youtubei_rs",Level::ERROR,"Error parsing next result: {}",err);
                 if client_config.dump_on_error {
                     tracing::event!(target: "youtubei_rs",Level::ERROR,"Dumping json for request with error: {}, CToken: {}",err, continuation);
-                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n ----------------------------------------------------", continuation));
+                    let mut log = String::from(&format!("---------------------------------------------------- \n CToken: {} \n Error {} \n----------------------------------------------------", continuation, err));
                     log += &json.to_string();
                     fs::write(format!("json_dump_endpoint_search_ctoken"), log).unwrap();
                 }

--- a/src/types/client.rs
+++ b/src/types/client.rs
@@ -100,12 +100,13 @@ pub struct ClientConfig{
    pub client_type: ClientTypes,
    pub region: String,
    pub proxy_region:String,
-   pub http_client: Client
+   pub http_client: Client,
+   pub dump_on_error: bool,
 }
 
 impl ClientConfig {
     /// Constructs a new ClientConfig with the client and all required headers
-    pub fn new(client_type: ClientTypes, region: String, proxy_region: String) -> Self {
+    pub fn new(client_type: ClientTypes, region: String, proxy_region: String, dump_on_error: bool) -> Self {
         let mut headers = header::HeaderMap::new();
         headers.insert("Content-Type", header::HeaderValue::from_static("application/json; charset=UTF-8"));
         headers.insert("Accept-Encoding", header::HeaderValue::from_static("gzip"));
@@ -121,7 +122,7 @@ impl ClientConfig {
         .default_headers(headers)
         .gzip(true)
         .build().unwrap();
-        Self { client_type, region, proxy_region, http_client: _http_client} 
+        Self { client_type, region, proxy_region, http_client: _http_client, dump_on_error} 
     }
 
     pub fn name(&self) ->  String {

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -120,7 +120,7 @@ pub struct CompactVideoRenderer{
     pub long_byline_text: Runs,
     pub published_time_text: Option<SimpleText>, // ONLY None if youtube returns a recommendation and the view count will be "Recommended to you"
     pub length_text: AccessibilitySimpleText,
-    pub view_count_text: Option<SimpleText>, // ONLY None if its a live stream
+    pub view_count_text: SimpleText,
     pub channel_thumbnail: Thumbnails,
     pub navigation_endpoint: NavigationEndpoint,
     pub badges: Option<Vec<BadgeRendererVec>>,

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -120,7 +120,7 @@ pub struct CompactVideoRenderer{
     pub long_byline_text: Runs,
     pub published_time_text: Option<SimpleText>, // ONLY None if youtube returns a recommendation and the view count will be "Recommended to you"
     pub length_text: AccessibilitySimpleText,
-    pub view_count_text: SimpleText,
+    pub view_count_text: Option<SimpleText>, // ONLY None if its a live stream
     pub channel_thumbnail: Thumbnails,
     pub navigation_endpoint: NavigationEndpoint,
     pub badges: Option<Vec<BadgeRendererVec>>,

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -126,7 +126,7 @@ pub struct CompactVideoRenderer{
     pub badges: Option<Vec<BadgeRendererVec>>,
     pub owner_badges:Option<Vec<BadgeRendererVec>>,
     pub short_byline_text: Runs,
-    pub short_view_count_text: AccessibilitySimpleText,
+    pub short_view_count_text: Title,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -120,13 +120,13 @@ pub struct CompactVideoRenderer{
     pub long_byline_text: Runs,
     pub published_time_text: Option<SimpleText>, // ONLY None if youtube returns a recommendation and the view count will be "Recommended to you"
     pub length_text: AccessibilitySimpleText,
-    pub view_count_text: SimpleText,
+    pub view_count_text: Title, // contains runs if video is live_now instead of simple_text
     pub channel_thumbnail: Thumbnails,
     pub navigation_endpoint: NavigationEndpoint,
     pub badges: Option<Vec<BadgeRendererVec>>,
     pub owner_badges:Option<Vec<BadgeRendererVec>>,
     pub short_byline_text: Runs,
-    pub short_view_count_text: Title,
+    pub short_view_count_text: Title,// contains runs if video is live_now instead of simple_text
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/types/video.rs
+++ b/src/types/video.rs
@@ -119,7 +119,7 @@ pub struct CompactVideoRenderer{
     pub title: Title,
     pub long_byline_text: Runs,
     pub published_time_text: Option<SimpleText>, // ONLY None if youtube returns a recommendation and the view count will be "Recommended to you"
-    pub length_text: AccessibilitySimpleText,
+    pub length_text: Option<AccessibilitySimpleText>, // None if its a live video
     pub view_count_text: Title, // contains runs if video is live_now instead of simple_text
     pub channel_thumbnail: Thumbnails,
     pub navigation_endpoint: NavigationEndpoint,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::types::{client, self};
 use crate::types::query_results::NextResult;
 
 pub fn default_client_config() -> ClientConfig {
-    ClientConfig::new(client::ClientTypes::Web,"US".to_string(),"US".to_string())
+    ClientConfig::new(client::ClientTypes::Web,"US".to_string(),"US".to_string(), true)
 }
 /// Used to merge 2 values into one, probably could be optimized
 pub fn merge(a: &mut Value, b: &Value) {


### PR DESCRIPTION
This dumps  the json response in the `pwd` directory the naming convention is `json_dump_endpoint`+ requested endpoint name e.g `browse`.
This feature needs to be impoved in regards the names because it gets overwritten which is bad.
The content of the file include request params, the error itself and the json data.